### PR TITLE
Experimental Target Occulting using Vincenty's Formulae and Earth Curvature

### DIFF
--- a/include/mixr/simulation/Station.hpp
+++ b/include/mixr/simulation/Station.hpp
@@ -183,6 +183,9 @@ public:
    bool isUpdateTimersEnabled() const;
    virtual bool setUpdateTimersEnable(const bool enb);
 
+   // Whether experimental (improved) terrain occulting is enabled
+   virtual bool isExpOccultingEnabled() const { return false; }
+
    // ---
    // Use these functions to process the time-critical, background and network
    // tasks if you're managing your own thread(s) from your main application

--- a/include/mixr/simulation/Station.hpp
+++ b/include/mixr/simulation/Station.hpp
@@ -183,6 +183,9 @@ public:
    bool isUpdateTimersEnabled() const;
    virtual bool setUpdateTimersEnable(const bool enb);
 
+   // Whether improved terrain occulting using Vincenty's method should be used for all targets
+   virtual bool isImprovedTerrainOccultingEnabled() const { return false; }
+
    // ---
    // Use these functions to process the time-critical, background and network
    // tasks if you're managing your own thread(s) from your main application

--- a/include/mixr/simulation/Station.hpp
+++ b/include/mixr/simulation/Station.hpp
@@ -183,9 +183,6 @@ public:
    bool isUpdateTimersEnabled() const;
    virtual bool setUpdateTimersEnable(const bool enb);
 
-   // Whether improved terrain occulting using Vincenty's method should be used for all targets
-   virtual bool isImprovedTerrainOccultingEnabled() const { return false; }
-
    // ---
    // Use these functions to process the time-critical, background and network
    // tasks if you're managing your own thread(s) from your main application

--- a/include/mixr/terrain/Terrain.hpp
+++ b/include/mixr/terrain/Terrain.hpp
@@ -91,8 +91,7 @@ public:
       const double refAlt,             // Ref altitude (meters)
       const double truBrg,             // True direction angle from north to look (degs)
       const double dist,               // Distance to check (meters)
-      const double tanLookAng,         // Tangent of the look angle
-      const double earthRadius         // Earth radius on target position
+      const double tanLookAng          // Tangent of the look angle
    ) const;
 
    // Returns true if the target at the altitude 'tgtAlt' and range 'range' is

--- a/include/mixr/terrain/Terrain.hpp
+++ b/include/mixr/terrain/Terrain.hpp
@@ -90,7 +90,8 @@ public:
       const double refAlt,             // Ref altitude (meters)
       const double truBrg,             // True direction angle from north to look (degs)
       const double dist,               // Distance to check (meters)
-      const double tanLookAng          // Tangent of the look angle
+      const double tanLookAng,         // Tangent of the look angle
+      const double earthRadius         // Earth radius on target position
    ) const;
 
    // Returns true if the target at the altitude 'tgtAlt' and range 'range' is

--- a/include/mixr/terrain/Terrain.hpp
+++ b/include/mixr/terrain/Terrain.hpp
@@ -79,7 +79,8 @@ public:
          const double refAlt,          // Ref altitude (meters)
          const double tgtLat,          // Target latitude (degs)
          const double tgtLon,          // Target longitude (degs)
-         const double tgtAlt           // Target altitude (meters)
+         const double tgtAlt,          // Tangent of the look angle
+         const double earthRadius      // Earth radius on target position
       ) const;
 
    // Returns true if any terrain in the 'truBrg' direction for 'dist' meters
@@ -102,7 +103,8 @@ public:
          const unsigned int n,           // Size of elevation and valdFlags arrays
          const double range,             // Range (meters)
          const double refAlt,            // Ref altitude (meters)
-         const double tgtAlt             // Target altitude (meters)
+         const double tgtAlt,            // Target altitude (meters)
+         const double earthRadius        // Earth radius on target position
       );
 
    // Returns true if any of the tangents of the angles (from level) to each

--- a/include/mixr/terrain/Terrain.hpp
+++ b/include/mixr/terrain/Terrain.hpp
@@ -80,7 +80,8 @@ public:
          const double tgtLat,          // Target latitude (degs)
          const double tgtLon,          // Target longitude (degs)
          const double tgtAlt,          // Tangent of the look angle
-         const double earthRadius      // Earth radius on target position
+         const double earthRadius,     // Earth radius on target position
+         const bool expOccultingEnabled // Whether experimental (improved) terrain occulting is enabled
       ) const;
 
    // Returns true if any terrain in the 'truBrg' direction for 'dist' meters
@@ -103,7 +104,8 @@ public:
          const double range,             // Range (meters)
          const double refAlt,            // Ref altitude (meters)
          const double tgtAlt,            // Target altitude (meters)
-         const double earthRadius        // Earth radius on target position
+         const double earthRadius,       // Earth radius on target position
+         const bool expOccultingEnabled  // Whether experimental (improved) terrain occulting is enabled
       );
 
    // Returns true if any of the tangents of the angles (from level) to each

--- a/src/models/Tdb.cpp
+++ b/src/models/Tdb.cpp
@@ -4,6 +4,7 @@
 #include "mixr/models/player/Player.hpp"
 #include "mixr/models/system/Gimbal.hpp"
 #include "mixr/models/WorldModel.hpp"
+#include "mixr/simulation/Station.hpp"
 
 #include "mixr/terrain/Terrain.hpp"
 
@@ -367,7 +368,7 @@ unsigned int Tdb::processPlayers(base::PairStream* const players)
                         // Terrain occulting check toward the space vehicle
                         occulted = terrain->targetOcculting2(osLat, osLon, osAlt, tbrg, dist, -tanTgtAng);
                      } else { 
-                        if(sim->getStation()->isImprovedTerrainOccultingEnabled()){
+                        if(ownship->getWorldModel()->getStation()->isImprovedTerrainOccultingEnabled()){
                            // Get the true, great-circle bearing to the target
                            double tbrg{}, distNM{};
                            base::nav::vll2bd(osLat, osLon, tgtLat, tgtLon, &tbrg, &distNM);

--- a/src/models/Tdb.cpp
+++ b/src/models/Tdb.cpp
@@ -14,6 +14,8 @@
 #include "mixr/base/util/nav_utils.hpp"
 #include "mixr/base/util/osg_utils.hpp"
 
+#include "mixr/simulation/Station.hpp"
+
 #include <cmath>
 
 namespace mixr {
@@ -369,7 +371,8 @@ unsigned int Tdb::processPlayers(base::PairStream* const players)
                      } else {
                         // Occulting check between two standard player
                         occulted = terrain->targetOcculting(osLat, osLon, static_cast<double>(osAlt),
-                                                            tgtLat, tgtLon, static_cast<double>(tgtAlt), earthRadius);
+                                                            tgtLat, tgtLon, static_cast<double>(tgtAlt), earthRadius,
+                                                            ownship->getWorldModel()->getStation()->isExpOccultingEnabled());
                      }
                   }
 

--- a/src/models/Tdb.cpp
+++ b/src/models/Tdb.cpp
@@ -366,7 +366,7 @@ unsigned int Tdb::processPlayers(base::PairStream* const players)
                         double dist{60.0 * base::distance::NM2M};
 
                         // Terrain occulting check toward the space vehicle
-                        occulted = terrain->targetOcculting2(osLat, osLon, osAlt, tbrg, dist, -tanTgtAng, earthRadius);
+                        occulted = terrain->targetOcculting2(osLat, osLon, osAlt, tbrg, dist, -tanTgtAng);
                      } else { 
                         if(ownship->getWorldModel()->getStation()->isImprovedTerrainOccultingEnabled()){
                            // Get the true, great-circle bearing to the target
@@ -377,7 +377,7 @@ unsigned int Tdb::processPlayers(base::PairStream* const players)
                            double dist = distNM * base::distance::NM2M;
                         
                            // Terrain occulting check toward the target using improved method
-                           occulted = terrain->targetOcculting2(osLat, osLon, osAlt, tbrg, dist, -tanTgtAng, earthRadius);
+                           occulted = terrain->targetOcculting2(osLat, osLon, osAlt, tbrg, dist, -tanTgtAng);
                         }
                         else {
                            occulted = terrain->targetOcculting(osLat, osLon, static_cast<double>(osAlt),

--- a/src/models/Tdb.cpp
+++ b/src/models/Tdb.cpp
@@ -366,10 +366,22 @@ unsigned int Tdb::processPlayers(base::PairStream* const players)
 
                         // Terrain occulting check toward the space vehicle
                         occulted = terrain->targetOcculting2(osLat, osLon, osAlt, tbrg, dist, -tanTgtAng);
-                     } else {
-                        // Occulting check between two standard player
-                        occulted = terrain->targetOcculting(osLat, osLon, static_cast<double>(osAlt),
-                                                            tgtLat, tgtLon, static_cast<double>(tgtAlt));
+                     } else { 
+                        if(sim->getStation()->isImprovedTerrainOccultingEnabled()){
+                           // Get the true, great-circle bearing to the target
+                           double tbrg{}, distNM{};
+                           base::nav::vll2bd(osLat, osLon, tgtLat, tgtLon, &tbrg, &distNM);
+
+                           // Set the distance to check to the actual distance of the target
+                           double dist = distNM * base::distance::NM2M;
+                        
+                           // Terrain occulting check toward the target using improved method
+                           occulted = terrain->targetOcculting2(osLat, osLon, osAlt, tbrg, dist, -tanTgtAng);
+                        }
+                        else {
+                           occulted = terrain->targetOcculting(osLat, osLon, static_cast<double>(osAlt),
+                           tgtLat, tgtLon, static_cast<double>(tgtAlt));
+                        }                  
                      }
                   }
 

--- a/src/models/Tdb.cpp
+++ b/src/models/Tdb.cpp
@@ -366,7 +366,7 @@ unsigned int Tdb::processPlayers(base::PairStream* const players)
                         double dist{60.0 * base::distance::NM2M};
 
                         // Terrain occulting check toward the space vehicle
-                        occulted = terrain->targetOcculting2(osLat, osLon, osAlt, tbrg, dist, -tanTgtAng);
+                        occulted = terrain->targetOcculting2(osLat, osLon, osAlt, tbrg, dist, -tanTgtAng, earthRadius);
                      } else { 
                         if(ownship->getWorldModel()->getStation()->isImprovedTerrainOccultingEnabled()){
                            // Get the true, great-circle bearing to the target
@@ -377,7 +377,7 @@ unsigned int Tdb::processPlayers(base::PairStream* const players)
                            double dist = distNM * base::distance::NM2M;
                         
                            // Terrain occulting check toward the target using improved method
-                           occulted = terrain->targetOcculting2(osLat, osLon, osAlt, tbrg, dist, -tanTgtAng);
+                           occulted = terrain->targetOcculting2(osLat, osLon, osAlt, tbrg, dist, -tanTgtAng, earthRadius);
                         }
                         else {
                            occulted = terrain->targetOcculting(osLat, osLon, static_cast<double>(osAlt),

--- a/src/models/Tdb.cpp
+++ b/src/models/Tdb.cpp
@@ -366,22 +366,10 @@ unsigned int Tdb::processPlayers(base::PairStream* const players)
 
                         // Terrain occulting check toward the space vehicle
                         occulted = terrain->targetOcculting2(osLat, osLon, osAlt, tbrg, dist, -tanTgtAng);
-                     } else { 
-                        if(sim->getStation()->isImprovedTerrainOccultingEnabled()){
-                           // Get the true, great-circle bearing to the target
-                           double tbrg{}, distNM{};
-                           base::nav::vll2bd(osLat, osLon, tgtLat, tgtLon, &tbrg, &distNM);
-
-                           // Set the distance to check to the actual distance of the target
-                           double dist = distNM * base::distance::NM2M;
-                        
-                           // Terrain occulting check toward the target using improved method
-                           occulted = terrain->targetOcculting2(osLat, osLon, osAlt, tbrg, dist, -tanTgtAng);
-                        }
-                        else {
-                           occulted = terrain->targetOcculting(osLat, osLon, static_cast<double>(osAlt),
-                           tgtLat, tgtLon, static_cast<double>(tgtAlt), earthRadius);
-                        }                  
+                     } else {
+                        // Occulting check between two standard player
+                        occulted = terrain->targetOcculting(osLat, osLon, static_cast<double>(osAlt),
+                                                            tgtLat, tgtLon, static_cast<double>(tgtAlt), earthRadius);
                      }
                   }
 

--- a/src/models/Tdb.cpp
+++ b/src/models/Tdb.cpp
@@ -381,7 +381,7 @@ unsigned int Tdb::processPlayers(base::PairStream* const players)
                         }
                         else {
                            occulted = terrain->targetOcculting(osLat, osLon, static_cast<double>(osAlt),
-                           tgtLat, tgtLon, static_cast<double>(tgtAlt));
+                           tgtLat, tgtLon, static_cast<double>(tgtAlt), earthRadius);
                         }                  
                      }
                   }

--- a/src/models/Tdb.cpp
+++ b/src/models/Tdb.cpp
@@ -4,7 +4,6 @@
 #include "mixr/models/player/Player.hpp"
 #include "mixr/models/system/Gimbal.hpp"
 #include "mixr/models/WorldModel.hpp"
-#include "mixr/simulation/Station.hpp"
 
 #include "mixr/terrain/Terrain.hpp"
 
@@ -368,7 +367,7 @@ unsigned int Tdb::processPlayers(base::PairStream* const players)
                         // Terrain occulting check toward the space vehicle
                         occulted = terrain->targetOcculting2(osLat, osLon, osAlt, tbrg, dist, -tanTgtAng);
                      } else { 
-                        if(ownship->getWorldModel()->getStation()->isImprovedTerrainOccultingEnabled()){
+                        if(sim->getStation()->isImprovedTerrainOccultingEnabled()){
                            // Get the true, great-circle bearing to the target
                            double tbrg{}, distNM{};
                            base::nav::vll2bd(osLat, osLon, tgtLat, tgtLon, &tbrg, &distNM);

--- a/src/terrain/Terrain.cpp
+++ b/src/terrain/Terrain.cpp
@@ -344,18 +344,23 @@ bool Terrain::occultCheck(
 
       if (validFlags == nullptr || validFlags[i]) {
          if(expOccultingEnabled){
+
+            // Compute the central angle (in radians) subtended by the current range (arc distance) over the effective Earth radius.
+            double cos_alpha = std::cos(currentRange / effEarthRadius);
+            double sin_alpha = std::sin(currentRange / effEarthRadius);
+
             // Calculate the curvature drop for the current distance
-            double curvature = effEarthRadius * (1.0 - std::cos(currentRange / effEarthRadius));
+            double curvature = effEarthRadius * (1.0 - cos_alpha);
 
             // Adjust elevations for the curvature
-            double adjustedTgtAlt = tgtAlt - curvature;
-            double adjustedGroundElev = elevations[i] - curvature;
+            double adjustedTgtAlt = tgtAlt*cos_alpha - curvature;
+            double adjustedGroundElev = elevations[i]*cos_alpha - curvature;
 
             // Calculate the slope between radar and target
-            double slopeTarget = (adjustedTgtAlt - refAlt) / currentRange;
+            double slopeTarget = (adjustedTgtAlt - refAlt) / (effEarthRadius*sin_alpha);
 
             // Calculate the slope between radar and ground
-            double slopeTerrain = (adjustedGroundElev - refAlt) / currentRange;
+            double slopeTerrain = (adjustedGroundElev - refAlt) / (effEarthRadius*sin_alpha);
 
             if (slopeTerrain > maxSlopeTerrain) {
                maxSlopeTerrain = slopeTerrain;

--- a/src/terrain/Terrain.cpp
+++ b/src/terrain/Terrain.cpp
@@ -249,8 +249,7 @@ bool Terrain::targetOcculting(
 
 //------------------------------------------------------------------------------
 // Target occulting #2: returns true if any terrain in the 'truBrg' direction
-// for 'dist' meters occults (or masks) a target with a look angle of atan(tanLookAng),
-// applying curvature correction.
+// for 'dist' meters occults (or masks) a target with a look angle of atan(tanLookAng)
 //------------------------------------------------------------------------------
 bool Terrain::targetOcculting2(
       const double refLat,    // Ref latitude (degs)
@@ -258,8 +257,7 @@ bool Terrain::targetOcculting2(
       const double refAlt,    // Ref altitude (meters)
       const double truBrg,    // True direction angle from north to look (degs)
       const double dist,      // Distance to check (meters)
-      const double tanLookAng, // Tangent of the look angle
-      const double earthRadius // Earth radius on target position
+      const double tanLookAng // Tangent of the look angle
    ) const
 {
    // 1200 points gives us 100 meter data up to a distance
@@ -288,21 +286,6 @@ bool Terrain::targetOcculting2(
 
       // And check occulting
       if (num > 0) {
-         // Apply standard atmospheric refraction factor (4/3)
-         // This accounts for downward bending of electromagnetic waves,
-         // effectively extending the line-of-sight (LOS) over the horizon
-         const double effEarthRadius = earthRadius * (4.0 / 3.0);   // Effective radius with refraction
-
-         // Distance between elevation samples
-         const double step = dist / static_cast<double>(numPts);
-
-         for (unsigned int i = 0; i < numPts; i++) {
-            if (validFlags[i]) {
-               double d = static_cast<double>(i + 1) * step;
-               double curvature = effEarthRadius * (1.0 - std::cos(d / effEarthRadius)); // Meters
-               elevations[i] -= curvature;
-            }
-         }
          occulted = occultCheck2(elevations, validFlags, numPts, dist, refAlt, tanLookAng);
       }
    }

--- a/src/terrain/Terrain.cpp
+++ b/src/terrain/Terrain.cpp
@@ -203,7 +203,8 @@ bool Terrain::targetOcculting(
       const double refAlt,    // Ref altitude (meters)
       const double tgtLat,    // Target latitude (degs)
       const double tgtLon,    // Target longitude (degs)
-      const double tgtAlt     // Target altitude (meters)
+      const double tgtAlt,    // Tangent of the look angle
+      const double earthRadius // Earth radius on target position
    ) const
 {
    // 1200 points gives us 100 meter data up to a distance
@@ -215,7 +216,7 @@ bool Terrain::targetOcculting(
    // Compute bearing and distance to target (flat earth)
    double brgDeg = 0.0;
    double distNM = 0.0;
-   base::nav::fll2bd(refLat, refLon, tgtLat, tgtLon, &brgDeg, &distNM);
+   base::nav::vll2bd(refLat, refLon, tgtLat, tgtLon, &brgDeg, &distNM);
    double dist = (distNM * base::distance::NM2M);
 
    // Number of points (default: 100M data)
@@ -239,7 +240,7 @@ bool Terrain::targetOcculting(
       // And check occulting
       if (num > 0) {
          occulted = occultCheck(elevations, validFlags, numPts, static_cast<double>(dist),
-                                refAlt, tgtAlt);
+                                refAlt, tgtAlt, earthRadius);
       }
    }
 
@@ -315,54 +316,66 @@ bool Terrain::targetOcculting2(
 // reference altitude 'refAlt'.
 //------------------------------------------------------------------------------
 bool Terrain::occultCheck(
-      const double* const elevations,  // The elevation array (meters)
-      const bool* const validFlags,    // Valid elevation flag array (true if elevation was found)
-      const unsigned int n,            // Size of the arrays
-      const double range,              // Range (meters)
-      const double refAlt,             // Ref altitude (meters)
-      const double tgtAlt)             // Target altitude (meters)
+   const double* const elevations,  // The elevation array (meters)
+   const bool* const validFlags,    // Valid elevation flag array (true if elevation was found)
+   const unsigned int n,            // Size of the arrays
+   const double range,              // Range (meters)
+   const double refAlt,             // Ref altitude (meters)
+   const double tgtAlt,             // Target altitude (meters)
+   const double earthRadius         // Earth radius on target position
+)             
 {
-   bool occulted = false;
+bool occulted = false;
 
-   // Early out checks
-   if (  elevations == nullptr ||    // The elevation array wasn't provided, or
-         n < 2 ||              // there are too few points, or
-         range <= 0            // the range is less than or equal to zero
-         ) return occulted;
+// Early out checks
+if (  elevations == nullptr ||    // The elevation array wasn't provided, or
+      n < 2 ||              // there are too few points, or
+      range <= 0            // the range is less than or equal to zero
+      ) return occulted;
 
-   // Tangent of the angle to the target point --
-   // If the angle to any terrain point is greater than this
-   // angle then the target is occulted by the terrain point
-   const double tgtTan = (tgtAlt - refAlt) / range;
+const double effEarthRadius = earthRadius * (4.0 / 3.0);  // Refraction factor applied      
+double maxSlopeTerrain = -1000;
 
-   // Loop through all elevation points looking for an angle
-   // that's greater than our ref angle
-   const double deltaRng = (range / (n - 1));
-   double currentRange = 0;
-   if (validFlags != nullptr) {
-      // with valid flags
-      for (unsigned int i = 1; i < (n-1) && !occulted; i++) {
-         currentRange += deltaRng;
-         if (validFlags[i]) {
-            const double tstTan = (elevations[i] - refAlt) / currentRange;
-            if (tstTan >= tgtTan) {
-               occulted = true;
-            }
-         }
+// Tangent of the angle to the target point --
+// If the angle to any terrain point is greater than this
+// angle then the target is occulted by the terrain point
+const double tgtTan = (tgtAlt - refAlt) / range;
+
+// Loop through all elevation points looking for an angle
+// that's greater than our ref angle
+const double deltaRng = (range / (n - 1));
+double currentRange = 0;
+
+// Loop structure: combine logic for both validFlags and non-validFlags cases
+for (unsigned int i = 1; i < (n-1) && !occulted; i++) {
+   currentRange += deltaRng;
+
+   if (validFlags == nullptr || validFlags[i]) {
+      // Calculate the curvature drop for the current distance
+      double curvature = effEarthRadius * (1.0 - std::cos(currentRange / effEarthRadius));
+
+      // Adjust elevations for the curvature
+      double adjustedTgtAlt = tgtAlt - curvature;
+      double adjustedGroundElev = elevations[i] - curvature;
+
+      // Calculate the slope between radar and target
+      double slopeTarget = (adjustedTgtAlt - refAlt) / currentRange;
+
+      // Calculate the slope between radar and ground
+      double slopeTerrain = (adjustedGroundElev - refAlt) / currentRange;
+
+      if (slopeTerrain > maxSlopeTerrain) {
+         maxSlopeTerrain = slopeTerrain;
+      }
+
+      // If the terrain slope is greater than the target slope, it's occulted
+      if (maxSlopeTerrain > slopeTarget || adjustedGroundElev > adjustedTgtAlt) {
+         occulted = true;
       }
    }
-   else {
-      // without valid flags
-      for (unsigned int i = 1; i < (n-1) && !occulted; i++) {
-         currentRange += deltaRng;
-         const double tstTan = (elevations[i] - refAlt) / currentRange;
-         if (tstTan >= tgtTan) {
-            occulted = true;
-         }
-      }
-   }
+}
 
-   return occulted;
+return occulted;
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Implementa a ocultação aprimorada pelo terreno na detecção de alvos (caso exemplo: Radar de solo e Aeronave). Pull request aberto para acompanhar alterações que de fato serão mergeadas, mas deve aguardar até ter um OK em conjunto da equipe.